### PR TITLE
Fix callback to JupyterHub

### DIFF
--- a/yarnspawner/singleuser.py
+++ b/yarnspawner/singleuser.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from jupyterhub.singleuser import SingleUserNotebookApp
@@ -13,9 +14,9 @@ class YarnSingleUserNotebookApp(SingleUserNotebookApp):
         return random_port()
 
     def start(self):
-        self.hub_auth._api_request(method='POST',
-                                   url=url_path_join(self.hub_api_url, 'yarnspawner'),
-                                   json={'port': self.port})
+        self.io_loop.add_callback(self.hub_auth._api_request, method='POST',
+                                  url=url_path_join(self.hub_api_url, 'yarnspawner'),
+                                  body=json.dumps({'port': self.port}))
         super().start()
 
 


### PR DESCRIPTION
```
/var/lib/hadoop/dev2/yarn/nm-local-dir/usercache/khroliz/appcache/application_1672066289436_0007/container_e137_1672066289436_0007_01_000001/notebook/lib/python3.9/site-packages/yarnspawner/singleuser.py:16: RuntimeWarning: coroutine 'HubAuth._api_request' was never awaited
  self.hub_auth._api_request(method='POST',
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```